### PR TITLE
decouple some config to .env + suggestion on security

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,3 @@
-HOME=/home/myuser
+HOME_DIR=/home/myuser
 PIHOLE_WEBPASSWORD=yoursecurepassword
 KAIZOKU_DB_PASSWORD=yoursecurepassword

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+HOME=/home/myuser
+PIHOLE_WEBPASSWORD=yoursecurepassword
+KAIZOKU_DB_PASSWORD=yoursecurepassword

--- a/README.md
+++ b/README.md
@@ -1,12 +1,46 @@
-## Docker Compose Scripts for my Home Server
+# Docker Compose Scripts for Home Server
 
-This is my personal config. You will need to tweak it to your needs.
+This repository contains Docker Compose scripts for setting up a home server. The configuration provided is personal and may need to be adjusted according to your specific requirements.
 
-Example of usage:
+## Prerequisites
 
+- Docker and Docker Compose installed on your server
+- SSH access to your server
+
+## Usage
+
+1. Copy all files to your server:
+
+   ```bash
+   scp * user@your-server.local:~/docker/
+   ```
+
+2. SSH into your server:
+
+   ```bash
+   ssh user@your-server.local
+   ```
+
+3. Navigate to the `docker` directory:
+
+   ```bash
+   cd docker
+   ```
+
+4. Run the Docker Compose file:
+
+   ```bash
+   docker compose -f infra-docker-compose.yml up -d
+   ```
+
+## Configuration
+
+The `.env.sample` file in this repository contains sample environment variables that are used by the Docker Compose scripts. Before running the scripts, you should rename this file to `.env` and update the variables to match your environment.
+
+To rename the file, use the following command:
+
+```bash
+mv .env.sample .env
 ```
-scp * akitaonrails@plex.local:~/docker/
-ssh akitaonrails@plex.local
-cd docker
-docker compose -f infra-docker-compose.yml up -d
-```
+
+After renaming, open the .env file and replace the placeholder values with your actual data. Save the file and proceed with the steps in the Usage section above.

--- a/infra-docker-compose.yml
+++ b/infra-docker-compose.yml
@@ -1,6 +1,6 @@
-version: '3'
+version: "3"
 
-name: 'net'
+name: "net"
 
 services:
   cloudflared:
@@ -21,13 +21,13 @@ services:
       - cloudflared
     environment:
       - DNSMASQ_USER=pihole
-      - WEBPASSWORD=ekCiN8!8b8ciNt2YmFAER
+      - WEBPASSWORD=${PIHOLE_WEBPASSWORD}
       - TZ=America/Sao_Paulo
       - PIHOLE_DNS_=127.0.0.1#5054
       - WEB_PORT=8053
     volumes:
-      - /home/akitaonrails/dnsmasq.d:/etc/dnsmasq.d
-      - /home/akitaonrails/pihole:/etc/pihole
+      - ${HOME_DIR}/dnsmasq.d:/etc/dnsmasq.d
+      - ${HOME_DIR}/pihole:/etc/pihole
     network_mode: host
     cap_add:
       - NET_RAW
@@ -45,7 +45,7 @@ services:
     image: zerotier/zerotier:latest
     restart: unless-stopped
     volumes:
-      - /home/akitaonrails/zerotier:/var/lib/zerotier-one
+      - ${HOME_DIR}/zerotier:/var/lib/zerotier-one
     devices:
       - /dev/net/tun:/dev/net/tun
     cap_add:
@@ -62,6 +62,6 @@ services:
       - PUID=1000
       - PGID=1000
     volumes:
-      - /home/akitaonrails/librespeed:/config
+      - ${HOME_DIR}/librespeed:/config
     ports:
-      - '9091:80'
+      - "9091:80"

--- a/kaizoku-docker-compose.yml
+++ b/kaizoku-docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 name: kaizoku
 
@@ -11,7 +11,7 @@ services:
     container_name: kaizoku
     image: ghcr.io/oae/kaizoku:latest
     environment:
-      - DATABASE_URL=postgresql://kaizoku:kaizoku@kaizoku-db:5432/kaizoku
+      - DATABASE_URL=postgresql://kaizoku:${KAIZOKU_DB_PASSWORD}@kaizoku-db:5432/kaizoku
       - KAIZOKU_PORT=3000
       - REDIS_HOST=redis
       - REDIS_PORT=6379
@@ -26,7 +26,7 @@ services:
       kaizoku-db:
         condition: service_healthy
     ports:
-      - '3000:3000'
+      - "3000:3000"
   redis:
     image: redis:7-alpine
     volumes:
@@ -35,14 +35,14 @@ services:
     image: postgres:alpine
     restart: unless-stopped
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U kaizoku']
+      test: ["CMD-SHELL", "pg_isready -U kaizoku"]
       interval: 5s
       timeout: 5s
       retries: 5
     environment:
       - POSTGRES_USER=kaizoku
       - POSTGRES_DB=kaizoku
-      - POSTGRES_PASSWORD=kaizoku
+      - POSTGRES_PASSWORD=${KAIZOKU_DB_PASSWORD}
     volumes:
       - kaizoku-db:/var/lib/postgresql/data
 
@@ -50,7 +50,7 @@ services:
     image: kizaing/kavita:latest
     restart: unless-stopped
     volumes:
-      - /home/akitaonrails/kavita:/kavita/config
+      - ${HOME_DIR}/kavita:/kavita/config
       - /mnt/terachad/Manga/Library:/manga
     ports:
-      - '5000:5000'
+      - "5000:5000"

--- a/media-library-docker-compose.yml
+++ b/media-library-docker-compose.yml
@@ -1,6 +1,6 @@
-version: '3'
+version: "3"
 
-name: 'media'
+name: "media"
 
 services:
   qbittorrent:
@@ -12,11 +12,11 @@ services:
       - PUID=1000
       - PGID=1000
     volumes:
-      - /home/akitaonrails/qbittorrent/config:/config
+      - ${HOME_DIR}/qbittorrent/config:/config
       - /mnt/terachad/Downloads/torrents:/downloads
     ports:
-      - '8080:8080'
-      - '62609:62609'
+      - "8080:8080"
+      - "62609:62609"
 
   jackett:
     image: ghcr.io/linuxserver/jackett:latest
@@ -26,10 +26,10 @@ services:
       - PUID=1000
       - PGID=1000
     volumes:
-      - /home/akitaonrails/jackett/downloads:/downloads
-      - /home/akitaonrails/jackett/config:/config
+      - ${HOME_DIR}/jackett/downloads:/downloads
+      - ${HOME_DIR}/jackett/config:/config
     ports:
-      - '9117:9117'
+      - "9117:9117"
 
   bazarr:
     image: ghcr.io/linuxserver/bazarr:latest
@@ -41,9 +41,9 @@ services:
     volumes:
       - /mnt/terachad/Videos/radarr:/movies
       - /mnt/terachad/Videos/sonarr:/tv
-      - /home/akitaonrails/bazarr/appdata/config:/config
+      - ${HOME_DIR}/bazarr/appdata/config:/config
     ports:
-      - '6767:6767'
+      - "6767:6767"
 
   overseerr:
     image: sctx/overseerr
@@ -54,9 +54,9 @@ services:
       - TZ=America/Sao_Paulo
       - PORT=5055
     volumes:
-      - /home/akitaonrails/overseerr/config:/app/config
+      - ${HOME_DIR}/overseerr/config:/app/config
     ports:
-      - '5055:5055'
+      - "5055:5055"
 
   prowlarr:
     image: ghcr.io/hotio/prowlarr:latest
@@ -68,17 +68,17 @@ services:
       - PUID=1000
       - PGID=1000
     volumes:
-      - /home/akitaonrails/prowlarr/config:/config
+      - ${HOME_DIR}/prowlarr/config:/config
     ports:
-      - '9696:9696'
+      - "9696:9696"
 
   flaresolverr:
     image: ghcr.io/flaresolverr/flaresolverr:latest
     restart: unless-stopped
     volumes:
-      - /home/akitaonrails/flaresolverr/config:/config
+      - ${HOME_DIR}/flaresolverr/config:/config
     ports:
-      - '8191:8191'
+      - "8191:8191"
 
   sabnzbd:
     image: lscr.io/linuxserver/sabnzbd:latest
@@ -90,9 +90,9 @@ services:
     volumes:
       - /mnt/terachad/Downloads/nzbget:/downloads
       - /mnt/terachad/Downloads/nzbget/incomplete:/incomplete-downloads
-      - /home/akitaonrails/nzbget/config:/config
+      - ${HOME_DIR}/nzbget/config:/config
     ports:
-      - '6789:6789'
+      - "6789:6789"
 
   radarr:
     image: ghcr.io/linuxserver/radarr:latest
@@ -104,12 +104,12 @@ services:
       - PUID=1000
       - PGID=1000
     volumes:
-      - /home/akitaonrails/radarr/appdata/config:/config
+      - ${HOME_DIR}/radarr/appdata/config:/config
       - /mnt/terachad/Downloads/torrents:/downloads
       - /mnt/terachad/Videos/radarr/movies:/movies
       - /mnt/terachad/Videos/radarr/anime:/anime
     ports:
-      - '7878:7878'
+      - "7878:7878"
 
   sonarr:
     image: ghcr.io/linuxserver/sonarr:latest
@@ -121,11 +121,11 @@ services:
       - PUID=1000
       - PGID=1000
     volumes:
-      - /home/akitaonrails/sonarr/appdata/config:/config
+      - ${HOME_DIR}/sonarr/appdata/config:/config
       - /mnt/terachad/Videos/sonarr:/tv
       - /mnt/terachad/Downloads/torrents:/downloads
     ports:
-      - '8989:8989'
+      - "8989:8989"
 
   plex:
     image: plexinc/pms-docker:latest
@@ -136,9 +136,9 @@ services:
       - PGID=1000
       - VA_DRIVER=IHD
     volumes:
-      - /home/akitaonrails/plex/config:/config
-      - /home/akitaonrails/plex/data:/data
-      - /home/akitaonrails/plex/transcode:/transcode
+      - ${HOME_DIR}/plex/config:/config
+      - ${HOME_DIR}/plex/data:/data
+      - ${HOME_DIR}/plex/transcode:/transcode
       - /mnt/terachad/Videos:/media
     devices:
       - /dev/dri:/dev/dri


### PR DESCRIPTION
Description:

This pull request introduces a .env.sample file for secure environment variable management and updates the Docker Compose files to use these variables. Additionally, the README is revised to guide users on setting up their .env file.

Key Changes:

- Added .env.sample with variables like HOME, PIHOLE_WEBPASSWORD, and KAIZOKU_DB_PASSWORD.
- Updated Docker Compose files to reference variables from .env.
- Updated README with instructions for using .env.sample.

Security Note:

- Rewrote history to remove hardcoded WEBPASSWORD. This change is on the [main-safe-history](https://github.com/pietrobondioli/plex-docker-compose/tree/main-safe-history) 
- Repository owner should consider force-pushing this branch to the main to remove the exposed credentials from history.

( I tried to open a pull request with the rewritten history but looks like github doesn't allow this kind of operation :/ )

![image](https://github.com/akitaonrails/plex-docker-compose/assets/55422938/9345fd6d-596d-414c-a430-16d0e700295a)
